### PR TITLE
Update sponsorship page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 .Rproj.user/028FC1A2/pcs/source-pane.pper
 .source-pane.pper
 /.Rproj.user
+_site

--- a/sponsorship.md
+++ b/sponsorship.md
@@ -4,38 +4,38 @@ title: Participation bursary and sponsorship
 <!--cover-img: /assets/img/events_blank.png-->
 ---
 
-We’re excited this year to launch our participation support bursary (also known as a microgrant)! We recognise that participation in online events can be challenging for people in different ways, and we’d like to remove these barriers as much as possible. 
+We’re excited this year to launch our **participation support bursary** (also known as a microgrant)! We recognise that participation in online events can be challenging for people in different ways, and we’d like to remove these barriers as much as possible. 
 
-## FAQ for BTSCon Participants: :
+## FAQ for BTSCon Participants:
 
-**Q:** What can I ask for?  
+**Q: What can I ask for?**
 **A:** Generally, we offer support in the form of one or more of the following: 
-- Small hardware: Headset, microphone, webcam, ring lighting.
-- Internet: 1 month of high-speed internet 
-- Diesel or other fuel for generators
-- Childcare costs for the duration of the event
-- Hotel or co-working space for the duration of the event. 
+- **Small hardware:** Headset, microphone, webcam, ring lighting.
+- **Internet:** 1 month of high-speed internet.
+- **Diesel** or other fuel for generators.
+- **Childcare costs** for the duration of the event.
+- **Hotel or co-working space** for the duration of the event. 
 
-[OLS](https://we-are-ols.org) will administer the microgrants - for more information, see OLS’s microgrant policies: https://openlifesci.org/openseeds/cohort-procedures-and-templates/microgrants.html#microgrant-recommendations-and-tips 
+[OLS](https://we-are-ols.org) will administer the microgrants - for more information, see [OLS’s microgrant policies](https://openlifesci.org/openseeds/cohort-procedures-and-templates/microgrants.html#microgrant-recommendations-and-tips).
 
-**Q:** Will I have to justify my request, write a blog, have an accepted session, or any other obligation from requesting a bursary?    
+**Q: Will I have to justify my request, write a blog, have an accepted session, or any other obligation from requesting a bursary?**    
 **A:** No :) Our goal is to make this as pain-free as possible. If you _want_ to write a blog, or submit a talk - please do so! 
 
-**Q:** I can't afford to pay for X and get reimbursed. Can I still apply?   
+**Q: I can't afford to pay for X and get reimbursed. Can I still apply?**    
 **A:** Please do! We offer three ways to get microgrants/bursaries:
 1. Share a purchase link and we'll ship it to your house on your behalf. 
 2. Purchase an item yourself, share a receipt, and we'll reimburse you. 
 3. Money up-front, if neither of the previous options work. 
 
-**Q:** Is there a $£€ limit to what I can ask for?   
+**Q: Is there a $£€ limit to what I can ask for?**    
 **A:** Generally no - we try not to quibble over reasonable requests, because we recognise that supply chains and fluctuating currencies make it hard to predict costs. The main exception: For a short conference, we're unable to pay for more than one month of internet or for large items like a laptop, monitor, or phone. If you go for top-of-the-line items, we might ask for you to come back with a cheaper (but still decent quality) alternative. 
   
-How to request a bursary: Please email [bigteamscienceconference@gmail.com](mailto:bigteamscienceconference@gmail.com) with a rough budget and the items you need. 
+**How to request a bursary:** Please email [bigteamscienceconference@gmail.com](mailto:bigteamscienceconference@gmail.com) with a rough budget and the items you need. 
   
 ## Information for sponsors  
 
-**Q:** How much can I donate, and what will it be used for?   
-**A:** Anything you offer can be helpful. We offer the following tiers (in USD) : 
+**Q: How much can I donate, and what will it be used for?**   
+**A:** Anything you offer can be helpful. We offer the following tiers (in USD): 
 
 | Sponsorship tier | What this might support*  | 
 | -------- | -------- | 


### PR DESCRIPTION
This PR is an extension of @yochannah's great work in #2. 🌷 
It was merged before I could review it. So, I put the changes in a fresh PR, rather than reverting the other.

**Changes in this PR:**
- Made the email link clickable.
- Formatted the text, mostly to make it more legible.
- Added the `_site` directory to the `.gitignore` file.

**See screenshot below:**

<img width="1900" alt="Screenshot of sponsorship page" src="https://github.com/bigteamscienceconference/bigteamscienceconference.github.io/assets/105166953/35aa7eb1-bf91-44df-99d1-3c773e232e7a">

Thanks for the review!